### PR TITLE
make jet work with django 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,11 @@
-==========
-Django JET -- with a temp jQuery Patch
-==========
+================================
+Django JET (Django-3 compatible) - with a temp jQuery Patch
+================================
 
 .. image:: https://travis-ci.org/geex-arts/django-jet.svg?branch=master
     :target: https://travis-ci.org/geex-arts/django-jet
 
-**Modern template for Django admin interface with improved functionality**
-
-+-----------------------------------------------------------------------------------------------------------------------------------+
-| Attention! **NEW JET**                                                                                                            |
-+===================================================================================================================================+
-| **We are proud to announce completely new Jet. Please check out Live Demo.**                                                      |
-|                                                                                                                                   |
-| Developing of new features for Django Jet will be frozen, only critical bugs will be fixed.                                       |
-+-----------------------------------------------------------------------------------------------------------------------------------+
-| `Live Demo <https://github.com/jet-admin/jet-bridge>`_                                                                            |
-+-----------------------------------------------------------------------------------------------------------------------------------+
-
+**Modern template for Django-3 admin interface with improved functionality**
 
 Django JET has two kinds of licenses: open-source (AGPLv3) and commercial. Please note that using AGPLv3
 code in your programs make them AGPL compatible too. So if you don't want to comply with that we can provide you a commercial
@@ -123,12 +112,12 @@ Installation
 
 .. code:: python
 
-    urlpatterns = patterns(
+    urlpatterns [
         '',
-        url(r'^jet/', include('jet.urls', 'jet')),  # Django JET URLS
-        url(r'^admin/', include(admin.site.urls)),
+        path('jet/', include('jet.urls', 'jet')),  # Django JET URLS
+        path('admin/', include(admin.site.urls)),
         ...
-    )
+    ]
 
 * Create database tables:
 
@@ -168,13 +157,21 @@ Dashboard installation
 
 .. code:: python
 
-    urlpatterns = patterns(
+    urlpatterns [
         '',
-        url(r'^jet/', include('jet.urls', 'jet')),  # Django JET URLS
-        url(r'^jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),  # Django JET dashboard URLS
-        url(r'^admin/', include(admin.site.urls)),
+        path('jet/', include('jet.urls', 'jet')),  # Django JET URLS
+        path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),  # Django JET dashboard URLS
+        path('admin/', include(admin.site.urls)),
         ...
-    )
+    ]
+
+.. warning::
+    From Django 3.0 the default value of the ``X_FRAME_OPTIONS`` setting was changed from ``SAMEORIGIN`` to ``DENY``. This       can cause errors for popups such as for the ``Field Lookup Popup``. To solve this you should add the following to your       Django project settings.py file:
+    
+.. code:: python
+        
+        X_FRAME_OPTIONS = 'SAMEORIGIN'
+        
 
 * **For Google Analytics widgets only** install python package:
 

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,10 +1,13 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    from six import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class UserDashboardModule(models.Model):

--- a/jet/dashboard/templates/admin/index.html
+++ b/jet/dashboard/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static jet_dashboard_tags static %}
+{% load i18n static jet_dashboard_tags static %}
 
 {% block html %}{% get_dashboard 'index' as dashboard %}{{ block.super }}{% endblock %}
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,8 +1,11 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    from six import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class Bookmark(models.Model):

--- a/jet/templates/admin/edit_inline/compact.html
+++ b/jet/templates/admin/edit_inline/compact.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static %}
+{% load i18n admin_urls static %}
 
 <div class="inline-group compact" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-prefix="{{ inline_admin_formset.formset.prefix }}" data-inline-verbose-name="{{ inline_admin_formset.opts.verbose_name|capfirst }}" data-inline-delete-text="{% trans "Remove" %}">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>

--- a/jet/templates/rangefilter/date_filter.html
+++ b/jet/templates/rangefilter/date_filter.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <script>
     function datefilter_apply(event, qs_name, form_name){

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,6 +1,9 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    from six import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class TestModel(models.Model):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 
 def get_install_requires():
-    install_requires = ['Django']
+    install_requires = ['Django', 'six']
 
     try:
         import importlib


### PR DESCRIPTION
This brings over changes that we need for django 3. Borrowing mostly from: (https://github.com/Barukimang/django-jet/)